### PR TITLE
feat: Add Localization Manager

### DIFF
--- a/src/main/java/de/griefed/ServerPackCreator/CLISetup.java
+++ b/src/main/java/de/griefed/ServerPackCreator/CLISetup.java
@@ -214,9 +214,9 @@ class CLISetup {
         String boolRead;
         while (true) {
             boolRead = readerBoolean.nextLine();
-            if (boolRead.matches("[Tt]rue") || boolRead.matches("1") || boolRead.matches("[Yy]es")|| boolRead.matches("[Yy]")) {
+            if (boolRead.matches("[Tt]rue") || boolRead.matches("1") || boolRead.matches("[Yy]es")|| boolRead.matches("[Yy]") || boolRead.matches(LocalizationManager.getLocalizedString("cli.input.yes")) || boolRead.matches(LocalizationManager.getLocalizedString("cli.input.yes.short"))) {
                 return true;
-            } else if (boolRead.matches("[Ff]alse") || boolRead.matches("0") || boolRead.matches("[Nn]o") || boolRead.matches("[Nn]" )){
+            } else if (boolRead.matches("[Ff]alse") || boolRead.matches("0") || boolRead.matches("[Nn]o") || boolRead.matches("[Nn]" ) || boolRead.matches(LocalizationManager.getLocalizedString("cli.input.no")) || boolRead.matches(LocalizationManager.getLocalizedString("cli.input.no.short"))){
                 return false;
             } else {
                 appLogger.error("Incorrect value specified. Please try again.");

--- a/src/main/java/de/griefed/ServerPackCreator/CLISetup.java
+++ b/src/main/java/de/griefed/ServerPackCreator/CLISetup.java
@@ -1,5 +1,6 @@
 package de.griefed.ServerPackCreator;
 
+import de.griefed.ServerPackCreator.i18n.LocalizationManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 

--- a/src/main/java/de/griefed/ServerPackCreator/Main.java
+++ b/src/main/java/de/griefed/ServerPackCreator/Main.java
@@ -13,6 +13,38 @@ public class Main {
      * @param args Command Line Argument determines whether ServerPackCreator will start into normal operation mode or with a step-by-step generation of a configuration file.
      */
     public static void main(String[] args) {
+        if (Arrays.asList(args).contains(Reference.LANG_ARGUMENT)) {
+            List<String> programArgs = Arrays.asList(args);
+            try {
+                LocalizationManager.init(programArgs.get(programArgs.indexOf(Reference.LANG_ARGUMENT) + 1));
+            } catch (IncorrectLanguageException e) {
+                appLogger.info(programArgs.get(programArgs.indexOf(Reference.LANG_ARGUMENT) + 1));
+                appLogger.error("Incorrect language specified, falling back to English (United States)...");
+                LocalizationManager.init();
+            }
+        } else if (Reference.langPropertiesFile.exists()) {
+            try {
+                LocalizationManager.init(Reference.langPropertiesFile);
+            } catch (IncorrectLanguageException e) {
+                appLogger.error("Incorrect language specified, falling back to English (United States)...");
+                LocalizationManager.init();
+            }
+        } else {
+            try (BufferedWriter writer = new BufferedWriter(new FileWriter(Reference.langPropertiesFile))) {
+                boolean langCreated = Reference.langPropertiesFile.createNewFile();
+                if (langCreated) {
+                    appLogger.debug(LocalizationManager.getLocalizedString("debug.lang_file_created"));
+                } else {
+                    appLogger.debug(LocalizationManager.getLocalizedString("debug.lang_file_failed"));
+                }
+                writer.write(String.format("# Supported languages: %s%n", Arrays.toString(LocalizationManager.getSupportedLanguages())));
+                writer.write(String.format("lang=en_us%n"));
+                LocalizationManager.init();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        
         String jarPath = null,
                jarName = null,
                javaVersion = null,

--- a/src/main/java/de/griefed/ServerPackCreator/Main.java
+++ b/src/main/java/de/griefed/ServerPackCreator/Main.java
@@ -1,11 +1,16 @@
 package de.griefed.ServerPackCreator;
 
+import de.griefed.ServerPackCreator.i18n.IncorrectLanguageException;
+import de.griefed.ServerPackCreator.i18n.LocalizationManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.io.BufferedWriter;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Arrays;
+import java.util.List;
 
 public class Main {
     private static final Logger appLogger = LogManager.getLogger(Main.class);
@@ -27,21 +32,21 @@ public class Main {
                 LocalizationManager.init(Reference.langPropertiesFile);
             } catch (IncorrectLanguageException e) {
                 appLogger.error("Incorrect language specified, falling back to English (United States)...");
-                LocalizationManager.init();
-            }
-        } else {
-            try (BufferedWriter writer = new BufferedWriter(new FileWriter(Reference.langPropertiesFile))) {
-                boolean langCreated = Reference.langPropertiesFile.createNewFile();
-                if (langCreated) {
-                    appLogger.debug(LocalizationManager.getLocalizedString("debug.lang_file_created"));
-                } else {
-                    appLogger.debug(LocalizationManager.getLocalizedString("debug.lang_file_failed"));
+                try (BufferedWriter writer = new BufferedWriter(new FileWriter(Reference.langPropertiesFile))) {
+                    if (!Reference.langPropertiesFile.exists()) {
+                        boolean langCreated = Reference.langPropertiesFile.createNewFile();
+                        if (langCreated) {
+                            appLogger.debug("Lang properties file created successfully.");
+                        } else {
+                            appLogger.debug("Lang properties file not created.");
+                        }
+                    }
+                    writer.write(String.format("# Supported languages: %s%n", Arrays.toString(LocalizationManager.getSupportedLanguages())));
+                    writer.write(String.format("lang=en_us%n"));
+                } catch (IOException ex) {
+                    ex.printStackTrace();
                 }
-                writer.write(String.format("# Supported languages: %s%n", Arrays.toString(LocalizationManager.getSupportedLanguages())));
-                writer.write(String.format("lang=en_us%n"));
                 LocalizationManager.init();
-            } catch (IOException e) {
-                e.printStackTrace();
             }
         }
         

--- a/src/main/java/de/griefed/ServerPackCreator/Reference.java
+++ b/src/main/java/de/griefed/ServerPackCreator/Reference.java
@@ -23,9 +23,7 @@ class Reference {
     static final File fabricLinuxFile = new File("start-fabric.sh");
     
     public static final String[] SUPPORTED_LANGUAGES = {
-            "en_us",
-            "uk_ua",
-            "ru_ru"
+            "en_us"
     };
 
     static Config config;

--- a/src/main/java/de/griefed/ServerPackCreator/Reference.java
+++ b/src/main/java/de/griefed/ServerPackCreator/Reference.java
@@ -21,6 +21,12 @@ class Reference {
     static final File forgeLinuxFile = new File("start-forge.sh");
     static final File fabricWindowsFile = new File("start-fabric.bat");
     static final File fabricLinuxFile = new File("start-fabric.sh");
+    
+    public static final String[] SUPPORTED_LANGUAGES = {
+            "en_us",
+            "uk_ua",
+            "ru_ru"
+    };
 
     static Config config;
 

--- a/src/main/java/de/griefed/ServerPackCreator/Reference.java
+++ b/src/main/java/de/griefed/ServerPackCreator/Reference.java
@@ -10,10 +10,12 @@ class Reference {
     static final String FABRIC_MANIFEST_URL = "https://maven.fabricmc.net/net/fabricmc/fabric-loader/maven-metadata.xml";
 
     static final String CONFIG_GEN_ARGUMENT = "-cgen";
+    static final String LANG_ARGUMENT = "-lang";
 
     static final File oldConfigFile = new File("creator.conf");
     static final File configFile = new File("serverpackcreator.conf");
     static final File propertiesFile = new File("server.properties");
+    static final File langPropertiesFile = new File("lang.properties");
     static final File iconFile = new File("server-icon.png");
     static final File forgeWindowsFile = new File("start-forge.bat");
     static final File forgeLinuxFile = new File("start-forge.sh");

--- a/src/main/java/de/griefed/ServerPackCreator/Reference.java
+++ b/src/main/java/de/griefed/ServerPackCreator/Reference.java
@@ -4,7 +4,7 @@ import com.typesafe.config.Config;
 import java.io.File;
 import java.util.List;
 
-class Reference {
+public class Reference {
     static final String MINECRAFT_MANIFEST_URL = "https://launchermeta.mojang.com/mc/game/version_manifest.json";
     static final String FORGE_MANIFEST_URL = "https://files.minecraftforge.net/maven/net/minecraftforge/forge/maven-metadata.json";
     static final String FABRIC_MANIFEST_URL = "https://maven.fabricmc.net/net/fabricmc/fabric-loader/maven-metadata.xml";

--- a/src/main/java/de/griefed/ServerPackCreator/i18n/IncorrectLanguageException.java
+++ b/src/main/java/de/griefed/ServerPackCreator/i18n/IncorrectLanguageException.java
@@ -1,0 +1,19 @@
+package de.griefed.ServerPackCreator.i18n;
+
+public class IncorrectLanguageException extends Exception {
+    public IncorrectLanguageException() {
+        super("Incorrect language specified");
+    }
+
+    public IncorrectLanguageException(String message) {
+        super(message);
+    }
+
+    public IncorrectLanguageException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public IncorrectLanguageException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/de/griefed/ServerPackCreator/i18n/LocalizationManager.java
+++ b/src/main/java/de/griefed/ServerPackCreator/i18n/LocalizationManager.java
@@ -1,5 +1,6 @@
 package de.griefed.ServerPackCreator.i18n;
 
+import de.griefed.ServerPackCreator.Reference;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -42,11 +43,7 @@ public class LocalizationManager {
     /**
      * List pf the languages that application supports. Must be formatted like this: en_us, de_de etc. Fields are case insensitive.
      */
-    private static final String[] SUPPORTED_LANGUAGES = {
-            "en_us",
-            "uk_ua",
-            "ru_ru"
-    };
+
 
     /**
      * @throws IncorrectLanguageException Thrown if the language specified in the properties file is not supported by SPC or specified in the invalid format.
@@ -54,7 +51,7 @@ public class LocalizationManager {
      */
     public static void init(String locale) throws IncorrectLanguageException {
         boolean isLanguageExists = false;
-        for (String lang: SUPPORTED_LANGUAGES) {
+        for (String lang: Reference.SUPPORTED_LANGUAGES) {
             if (lang.equalsIgnoreCase(locale)) {
                 logger.debug("Lang is correct");
                 isLanguageExists = true;
@@ -96,7 +93,7 @@ public class LocalizationManager {
 
         boolean isLanguageExists = false;
 
-        for (String lang: SUPPORTED_LANGUAGES) {
+        for (String lang: Reference.SUPPORTED_LANGUAGES) {
             if (lang.equalsIgnoreCase(langProp)) {
                 logger.debug("Lang is correct");
                 isLanguageExists = true;
@@ -156,6 +153,6 @@ public class LocalizationManager {
     }
 
     public static String[] getSupportedLanguages() {
-        return SUPPORTED_LANGUAGES;
+        return Reference.SUPPORTED_LANGUAGES;
     }
 }

--- a/src/main/java/de/griefed/ServerPackCreator/i18n/LocalizationManager.java
+++ b/src/main/java/de/griefed/ServerPackCreator/i18n/LocalizationManager.java
@@ -1,0 +1,161 @@
+package de.griefed.ServerPackCreator.i18n;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+/**
+ * This class is localization manager for your application.
+ * <p>To use it, firstly run LocalizationManager.init().
+ * Then use LocalizationManager.getLocalizedString() to find the localized string in config file.
+ * All localization config files need to be stored in <code>resources/i18n</code> directory
+ * and be named using following pattern: lang_{language code in lowercase}_{country code in lowercase}.
+ * For example: lang_en_us.lang.</p>
+ * Currently supports only strings to be used in localized fields.
+ */
+public class LocalizationManager {
+
+
+    private static final Logger logger = LogManager.getLogger("LocaleLogger");
+    /**
+     * Current language of application, mapped for easier further reference.
+     */
+    private static Map<String, String> currentLanguage = new HashMap<>();
+
+    /**
+     * Localized strings that application uses.
+     */
+    private static ResourceBundle localeResources;
+
+    /**
+     * Keys that used for current language mapping.
+     */
+    private static final String LANGUAGE_MAP_PATH = "language";
+    private static final String COUNTRY_MAP_PATH = "country";
+
+    /**
+     * List pf the languages that application supports. Must be formatted like this: en_us, de_de etc. Fields are case insensitive.
+     */
+    private static final String[] SUPPORTED_LANGUAGES = {
+            "en_us",
+            "uk_ua",
+            "ru_ru"
+    };
+
+    /**
+     * @throws IncorrectLanguageException Thrown if the language specified in the properties file is not supported by SPC or specified in the invalid format.
+     * @param locale Locale to be used by application in this run.
+     */
+    public static void init(String locale) throws IncorrectLanguageException {
+        boolean isLanguageExists = false;
+        for (String lang: SUPPORTED_LANGUAGES) {
+            if (lang.equalsIgnoreCase(locale)) {
+                logger.debug("Lang is correct");
+                isLanguageExists = true;
+                break;
+            }
+        }
+        if (Boolean.FALSE.equals(isLanguageExists)) throw new IncorrectLanguageException();
+        String[] langCode;
+        if (locale.contains("_")) {
+            langCode = locale.split("_");
+            currentLanguage.put(LANGUAGE_MAP_PATH, langCode[0]);
+            currentLanguage.put(COUNTRY_MAP_PATH, langCode[1]);
+        } else {
+            throw new IncorrectLanguageException();
+        }
+        localeResources = ResourceBundle.getBundle(String.format("i18n.lang.lang_%s", locale));
+        logger.info(String.format("Using language: %s", getLocalizedString("localeUnlocalizedName")));
+        if (!currentLanguage.get(LANGUAGE_MAP_PATH).equalsIgnoreCase("en")) {
+            logger.info(String.format("%s %s", getLocalizedString("cli.usingLanguage"), getLocalizedString("localeName")));
+        }
+
+    }
+
+    /**
+     * @param localePropertiesFile Path to the properties file with the language specified.
+     * @throws IncorrectLanguageException Thrown if the language specified in the properties file is not supported by SPC or specified in the invalid format.
+     */
+    public static void init(File localePropertiesFile) throws IncorrectLanguageException{
+        Properties langProperties = new Properties();
+        try (FileInputStream fis = new FileInputStream(localePropertiesFile)){
+            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(fis, StandardCharsets.UTF_8));
+            langProperties.load(bufferedReader);
+            logger.debug(String.format("langProperties = %s", langProperties));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        String langProp = langProperties.getProperty("lang");
+        logger.debug(langProp);
+
+        boolean isLanguageExists = false;
+
+        for (String lang: SUPPORTED_LANGUAGES) {
+            if (lang.equalsIgnoreCase(langProp)) {
+                logger.debug("Lang is correct");
+                isLanguageExists = true;
+                break;
+            }
+        }
+
+        if (Boolean.FALSE.equals(isLanguageExists)) throw new IncorrectLanguageException();
+        String defaultLocale = "en_us";
+        String langProperty = langProperties.getProperty("lang", defaultLocale);
+        String[] langCode;
+        if (langProperty.contains("_")) {
+            langCode = langProperty.split("_");
+            currentLanguage.put(LANGUAGE_MAP_PATH, langCode[0]);
+            currentLanguage.put(COUNTRY_MAP_PATH, langCode[1]);
+        } else {
+            throw new IncorrectLanguageException();
+        }
+
+        localeResources = ResourceBundle.getBundle(String.format("resources.i18n.lang_%s", langProperties.getProperty("lang")), new Locale(currentLanguage.get(LANGUAGE_MAP_PATH), currentLanguage.get(COUNTRY_MAP_PATH)));
+        logger.info(String.format("Using language: %s", getLocalizedString("localeUnlocalizedName")));
+        if (!currentLanguage.get(LANGUAGE_MAP_PATH).equalsIgnoreCase("en")) {
+            logger.info(String.format("%s %s", getLocalizedString("cli.usingLanguage"), getLocalizedString("localeName")));
+        }
+
+    }
+
+    /**
+     * Initializer with default localization properties path.
+     */
+    public static void init() {
+        try {
+            init("en_us");
+        } catch (IncorrectLanguageException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Gets localized string from localization resource bundle.
+     * @param languageKey The language key to search for.
+     * @return Localized string that is referred by the language key.
+     */
+    public static String getLocalizedString(String languageKey) {
+        try {
+            String value =  localeResources.getString(languageKey);
+            return new String(value.getBytes(StandardCharsets.ISO_8859_1), StandardCharsets.UTF_8);
+        } catch (MissingResourceException ex) {
+            logger.error(String.format("ERROR: Language key %s not found in the language file.", ex.getKey()));
+            System.exit(8);
+        }
+        return null;
+    }
+
+    public static String getLocale() {
+        return String.format("%s_%s", currentLanguage.get(LANGUAGE_MAP_PATH), currentLanguage.get(COUNTRY_MAP_PATH));
+    }
+
+    public static String[] getSupportedLanguages() {
+        return SUPPORTED_LANGUAGES;
+    }
+}

--- a/src/main/resources/de/griefed/resources/lang/lang_en_us.properties
+++ b/src/main/resources/de/griefed/resources/lang/lang_en_us.properties
@@ -1,0 +1,11 @@
+# Untranslated language name (in English)
+localeUnlocalizedName=English (United States)
+# Translated language name (in language you translating the app currently to.)
+localeName=English (US)
+
+cli.usingLanguage=Using language:
+
+cli.input.yes=[Yy]es
+cli.input.yes.short=[Yy]
+cli.input.no=[Nn]o
+cli.input.no.short=[Nn]

--- a/src/main/resources/de/griefed/resources/lang/lang_uk_ua.properties
+++ b/src/main/resources/de/griefed/resources/lang/lang_uk_ua.properties
@@ -1,0 +1,11 @@
+# Untranslated language name (in English)
+localeUnlocalizedName=Ukrainian (Ukraine)
+# Translated language name (in language you translating the app currently to.)
+localeName=Українська (Україна)
+
+cli.usingLanguage=Використовується мова:
+
+cli.input.yes=[Тт]ак
+cli.input.yes.short=[Тт]
+cli.input.no=[Нн]і
+cli.input.no.short=[Нн]


### PR DESCRIPTION
To add a new language to the app you need:

1. Create resources/de/griefed/resources/lang/lang_`language code`.lang file.
2. Add `language code` to the SUPPORTED_LANGUAGES list in Reference
3. Translate the app!

Please keep in mind that auto fallback to English when locale key doesn't exist in current language is not implemented yet.
Now @Griefed need to replace all messages that he wants to be translatable with `LocalizationManager.getLocalizedString(<translation key>)` and, obviously, add this messages to lang_en_us.lang under translation keys that are exact the same as it mentioned in code.