### PR TITLE
fix: add missing redirect to `/dev/null` in default_template.sh

### DIFF
--- a/serverpackcreator-api/src/main/resources/de/griefed/resources/server_files/default_template.sh
+++ b/serverpackcreator-api/src/main/resources/de/griefed/resources/server_files/default_template.sh
@@ -163,7 +163,7 @@ refreshServerJar() {
     SERVERSTARTERJAR_DOWNLOAD_URL="https://github.com/neoforged/ServerStarterJar/releases/download/${SERVERSTARTERJAR_VERSION}/server.jar"
   fi
 
-  downloadIfNotExist "server.jar" "server.jar" "${SERVERSTARTERJAR_DOWNLOAD_URL}"
+  downloadIfNotExist "server.jar" "server.jar" "${SERVERSTARTERJAR_DOWNLOAD_URL}" >/dev/null
 }
 
 # setupForge


### PR DESCRIPTION
Add redirect to `/dev/null` for `downloadIfNotExist` in `refreshServerJar` in default_template.sh.

Before:
![image_2025-05-29_07-41-27](https://github.com/user-attachments/assets/6edb2b8e-a619-402b-a225-e647358b3f7f)

After:
![image_2025-05-29_07-37-54](https://github.com/user-attachments/assets/3498e521-ecf6-439b-bcf6-c4e5387f9020)
