### PR TITLE
fix(web): Fixed Mongo repository entity type resolution

### DIFF
--- a/serverpackcreator-app/src/main/kotlin/de/griefed/serverpackcreator/app/web/serverpack/customizing/ModRepository.kt
+++ b/serverpackcreator-app/src/main/kotlin/de/griefed/serverpackcreator/app/web/serverpack/customizing/ModRepository.kt
@@ -24,6 +24,6 @@ import org.springframework.data.repository.NoRepositoryBean
 import java.util.*
 
 @NoRepositoryBean
-interface ModRepository<T, ID> : MongoRepository<Any, Any> {
+interface ModRepository<T : Any, ID : Any> : MongoRepository<T, ID> {
     fun findByMod(mod: String) : Optional<T>
 }


### PR DESCRIPTION
## Description

This patch includes a fix for the entity type resolution for ModRepository, so that Spring Data MongoDB would be able to resolve concreate document types instead of `Any`/`Object`

The original problem was that ModRepository was declared raw instead of generic. This would cause the error of:

`Couldn't find PersistentEntity for type class java.lang.Object`

Changing the ModRepository type declaration fixes this issue, and allows the Spring Data MongoDB to initialize correctly.